### PR TITLE
counting resources under the correct lab account

### DIFF
--- a/gpus_users.bashrc
+++ b/gpus_users.bashrc
@@ -2,7 +2,7 @@
 usage_by_lab() {
     {
         sacctmgr -nop show assoc format=account,user,grptres | grep -v 'root' | grep -v 'test-lab';
-        squeue -O "UserName,StateCompact,QOS,tres-alloc:1000" -h | tr -s " " | awk '$0="G> "$0' | grep gpu | sort;
+        squeue -O "UserName,StateCompact,QOS,tres-alloc:1000,Account,Partition" -h | tr -s " " | awk '$0="G> "$0' | grep gpu | sort;
     } | awk -f $1 -
 }
 usage_by_node() {

--- a/lab_usage.awk
+++ b/lab_usage.awk
@@ -23,22 +23,29 @@ BEGIN {
 }
 {
     if ($1 == "G>") {
-        gpu_counts[$2][$3]+=$12;
-        gpu_counts[$2][$3,$4]+=$12;
+        # for overcap jobs, assign lab arbitrarily
+        if ($14 == "overcap"){
+            lab=user_to_lab[$2]
+        }
+        else{
+            lab=$13
+        }
+        gpu_counts[lab][$2][$3]+=$12;
+        gpu_counts[lab][$2][$3,$4]+=$12;
 
-        gpu_counts[$2]["R"]+=0;
-        gpu_counts[$2]["PD"]+=0;
-        gpu_counts[$2]["CG"]+=0;
+        gpu_counts[lab][$2]["R"]+=0;
+        gpu_counts[lab][$2]["PD"]+=0;
+        gpu_counts[lab][$2]["CG"]+=0;
 
-        cpu_counts[$2][$3]+=$7;
-        cpu_counts[$2][$3,$4]+=$7;
+        cpu_counts[lab][$2][$3]+=$7;
+        cpu_counts[lab][$2][$3,$4]+=$7;
 
-        cpu_counts[$2]["R"]+=0;
-        cpu_counts[$2]["PD"]+=0;
-        cpu_counts[$2]["CG"]+=0;
+        cpu_counts[lab][$2]["R"]+=0;
+        cpu_counts[lab][$2]["PD"]+=0;
+        cpu_counts[lab][$2]["CG"]+=0;
 
-        labs_to_gpus_used[user_to_lab[$2]][$3]+=$12;
-        labs_to_cpus_used[user_to_lab[$2]][$3]+=$7;
+        labs_to_gpus_used[lab][$3]+=$12;
+        labs_to_cpus_used[lab][$3]+=$7;
 
     } else {
         if ($5 == "gres/gpu") {
@@ -63,11 +70,11 @@ END {
             labs_to_gpus[lab])
         printf("| %14s | %-21s |\n", lab, print_str);
         print_row_separator()
-        for (name in gpu_counts){
-            if (user_to_lab[name] == lab) {
+        if (lab in gpu_counts) {
+            for (name in gpu_counts[lab]){
                 cpu_per_gpu_use_str = "-"
-                if (gpu_counts[name]["R"] > 0){
-                    cpu_per_gpu_use = (1.0*cpu_counts[name]["R"]) / gpu_counts[name]["R"]
+                if (gpu_counts[lab][name]["R"] > 0){
+                    cpu_per_gpu_use = (1.0*cpu_counts[lab][name]["R"]) / gpu_counts[lab][name]["R"]
                     # cpu_per_gpu_use_str = sprintf("%.1f", cpu_per_gpu_use)
                     if (cpu_per_gpu_use >= 10.0) {
                         cpu_per_gpu_use_str = sprintf("%d", cpu_per_gpu_use)
@@ -77,31 +84,31 @@ END {
 
                     run_str = sprintf(\
                         " %s (%s) |",\
-                        colour_int(gpu_counts[name]["R"]),\
+                        colour_int(gpu_counts[lab][name]["R"]),\
                         colour_str_custom(cpu_per_gpu_use_str, colour("Blue"), 3)\
                     )
                 } else {
-                    run_str = sprintf(" %9s |", colour_int(gpu_counts[name]["R"]))
+                    run_str = sprintf(" %9s |", colour_int(gpu_counts[lab][name]["R"]))
                 }
 
                 printf("| %14s |",name);
 
-                # printf(" %3d |",gpu_counts[name]["R"]);
-                # printf(" %3d |",gpu_counts[name]["PD"]);
-                # printf(" %3d |",gpu_counts[name]["CG"]);
+                # printf(" %3d |",gpu_counts[lab][name]["R"]);
+                # printf(" %3d |",gpu_counts[lab][name]["PD"]);
+                # printf(" %3d |",gpu_counts[lab][name]["CG"]);
 
                 # Colorized
                 # printf(\
                 #     " %s (%s) |",\
-                #     colour_int(gpu_counts[name]["R"]),\
+                #     colour_int(gpu_counts[lab][name]["R"]),\
                 #     colour_str_custom(cpu_per_gpu_use_str, colour("Blue"), 3)\
                 # );
                 printf(run_str);
-                printf(" %s |", colour_int(gpu_counts[name]["PD"]));
-                printf(" %s |", colour_int(gpu_counts[name]["CG"]));
+                printf(" %s |", colour_int(gpu_counts[lab][name]["PD"]));
+                printf(" %s |", colour_int(gpu_counts[lab][name]["CG"]));
 
 
-                # printf(" %s |", colour_int_blue(cpu_counts[name]["R"]));
+                # printf(" %s |", colour_int_blue(cpu_counts[lab][name]["R"]));
                 # printf(" %s |", colour_str_custom(cpu_per_gpu_use_str, colour("Blue"), 3));
 
                 printf("\n");

--- a/lab_usage_qos.awk
+++ b/lab_usage_qos.awk
@@ -13,17 +13,23 @@ BEGIN {
 }
 {
     if ($1 == "G>") {
-        gpu_counts[$2][$3]+=$12;
-        gpu_counts[$2][$3,$4]+=$12;
+        # for overcap jobs, assign lab arbitrarily
+        if ($14 == "overcap"){
+            lab=user_to_lab[$2]
+        }
+        else{
+            lab=$13
+        }
+        gpu_counts[lab][$2][$3]+=$12;
+        gpu_counts[lab][$2][$3,$4]+=$12;
 
-        gpu_counts[$2]["R"]+=0;
-        gpu_counts[$2]["R","normal"]+=0;
-        gpu_counts[$2]["R","overcap"]+=0;
+        gpu_counts[lab][$2]["R"]+=0;
+        gpu_counts[lab][$2]["R","normal"]+=0;
+        gpu_counts[lab][$2]["R","overcap"]+=0;
 
-        labs_to_gpus_used[user_to_lab[$2]][$3]+=$12;
-        lab_totals[user_to_lab[$2]][$3]+=$12;
-        lab_totals[user_to_lab[$2]][$3,$4]+=$12;
-
+        labs_to_gpus_used[lab][$3]+=$12;
+        lab_totals[lab][$3]+=$12;
+        lab_totals[lab][$3,$4]+=$12;
     } else {
         if ($5 == "gres/gpu") {
             labs_to_gpus[$1] += $12;
@@ -42,8 +48,8 @@ END {
         }
         print_str = sprintf("[ %d/%d/%d ]", labs_to_gpus_used[lab]["R"], labs_to_gpus_used[lab]["PD"], labs_to_gpus[lab])
         printf("| %14s | %-15s |\n", lab, print_str);
-        for (name in gpu_counts){
-            if (user_to_lab[name] == lab) {
+        if (lab in gpu_counts) {
+            for (name in gpu_counts[lab]){
                 printf("| %14s |",name);
 
                 # printf(" %3d |",gpu_counts[name]["R","normal"]);
@@ -51,9 +57,9 @@ END {
                 # printf(" %3d |",gpu_counts[name]["R"]);
 
                 # Colorized
-                printf(" %s |",colour_int(gpu_counts[name]["R","normal"]));
-                printf(" %s |",colour_int(gpu_counts[name]["R","overcap"]));
-                printf(" %s |",colour_int(gpu_counts[name]["R"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R","normal"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R","overcap"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R"]));
 
                 printf("\n");
             }

--- a/lab_usage_verbose.awk
+++ b/lab_usage_verbose.awk
@@ -26,44 +26,51 @@ BEGIN {
 }
 {
     if ($1 == "G>") {
+        # for overcap jobs, assign lab arbitrarily
+        if ($14 == "overcap"){
+            lab=user_to_lab[$2]
+        }
+        else {
+            lab=$13
+        }
         # GPU Counts
-        gpu_counts[$2][$3]+=$12;
-        gpu_counts[$2][$3,$4]+=$12;
+        gpu_counts[lab][$2][$3]+=$12;
+        gpu_counts[lab][$2][$3,$4]+=$12;
 
-        gpu_counts[$2]["R"]+=0;
-        gpu_counts[$2]["PD"]+=0;
-        gpu_counts[$2]["CG"]+=0;
+        gpu_counts[lab][$2]["R"]+=0;
+        gpu_counts[lab][$2]["PD"]+=0;
+        gpu_counts[lab][$2]["CG"]+=0;
 
-        gpu_counts[$2]["R","normal"]+=0;
-        gpu_counts[$2]["PD","normal"]+=0;
-        gpu_counts[$2]["CG","normal"]+=0;
-        gpu_counts[$2]["R","overcap"]+=0;
-        gpu_counts[$2]["PD","overcap"]+=0;
-        gpu_counts[$2]["CG","overcap"]+=0;
+        gpu_counts[lab][$2]["R","normal"]+=0;
+        gpu_counts[lab][$2]["PD","normal"]+=0;
+        gpu_counts[lab][$2]["CG","normal"]+=0;
+        gpu_counts[lab][$2]["R","overcap"]+=0;
+        gpu_counts[lab][$2]["PD","overcap"]+=0;
+        gpu_counts[lab][$2]["CG","overcap"]+=0;
 
         # CPU counts
-        cpu_counts[$2][$3]+=$6;
-        cpu_counts[$2][$3,$4]+=$6;
+        cpu_counts[lab][$2][$3]+=$6;
+        cpu_counts[lab][$2][$3,$4]+=$6;
 
-        cpu_counts[$2]["R"]+=0;
-        cpu_counts[$2]["PD"]+=0;
-        cpu_counts[$2]["CG"]+=0;
+        cpu_counts[lab][$2]["R"]+=0;
+        cpu_counts[lab][$2]["PD"]+=0;
+        cpu_counts[lab][$2]["CG"]+=0;
 
-        cpu_counts[$2]["R","normal"]+=0;
-        cpu_counts[$2]["PD","normal"]+=0;
-        cpu_counts[$2]["CG","normal"]+=0;
-        cpu_counts[$2]["R","overcap"]+=0;
-        cpu_counts[$2]["PD","overcap"]+=0;
-        cpu_counts[$2]["CG","overcap"]+=0;
+        cpu_counts[lab][$2]["R","normal"]+=0;
+        cpu_counts[lab][$2]["PD","normal"]+=0;
+        cpu_counts[lab][$2]["CG","normal"]+=0;
+        cpu_counts[lab][$2]["R","overcap"]+=0;
+        cpu_counts[lab][$2]["PD","overcap"]+=0;
+        cpu_counts[lab][$2]["CG","overcap"]+=0;
 
-        labs_to_gpus_used[user_to_lab[$2]][$3]+=$12;
-        labs_to_cpus_used[user_to_lab[$2]][$3]+=$6;
+        labs_to_gpus_used[lab][$3]+=$12;
+        labs_to_cpus_used[lab][$3]+=$6;
 
-        lab_gpu_totals[user_to_lab[$2]][$3]+=$12;
-        lab_cpu_totals[user_to_lab[$2]][$3]+=$6;
+        lab_gpu_totals[lab][$3]+=$12;
+        lab_cpu_totals[lab][$3]+=$6;
 
-        lab_gpu_totals[user_to_lab[$2]][$3,$4]+=$12;
-        lab_cpu_totals[user_to_lab[$2]][$3,$4]+=$6;
+        lab_gpu_totals[lab][$3,$4]+=$12;
+        lab_cpu_totals[lab][$3,$4]+=$6;
 
     } else {
         if ($5 == "gres/gpu") {
@@ -87,32 +94,32 @@ END {
             labs_to_gpus_used[lab]["PD"],
             labs_to_gpus[lab])
         printf("| %14s = %-51s |\n", lab, print_str);
-        for (name in gpu_counts){
-            if (user_to_lab[name] == lab) {
+        if (lab in gpu_counts) {
+            for (name in gpu_counts[lab]) {
                 printf("| %14s |",name);
-                # printf(" %3d |",gpu_counts[name]["R","normal"]);
-                # printf(" %3d |",gpu_counts[name]["PD","normal"]);
-                # printf(" %3d |",gpu_counts[name]["CG","normal"]);
+                # printf(" %3d |",gpu_counts[lab][name]["R","normal"]);
+                # printf(" %3d |",gpu_counts[lab][name]["PD","normal"]);
+                # printf(" %3d |",gpu_counts[lab][name]["CG","normal"]);
                 #
-                # printf(" %3d |",gpu_counts[name]["R","overcap"]);
-                # printf(" %3d |",gpu_counts[name]["PD","overcap"]);
-                # printf(" %3d |",gpu_counts[name]["CG","overcap"]);
+                # printf(" %3d |",gpu_counts[lab][name]["R","overcap"]);
+                # printf(" %3d |",gpu_counts[lab][name]["PD","overcap"]);
+                # printf(" %3d |",gpu_counts[lab][name]["CG","overcap"]);
                 #
-                # printf(" %3d |",gpu_counts[name]["R"]);
-                # printf(" %3d |",gpu_counts[name]["PD"]);
-                # printf(" %3d |",gpu_counts[name]["CG"]);
+                # printf(" %3d |",gpu_counts[lab][name]["R"]);
+                # printf(" %3d |",gpu_counts[lab][name]["PD"]);
+                # printf(" %3d |",gpu_counts[lab][name]["CG"]);
 
-                printf(" %s |",colour_int(gpu_counts[name]["R","normal"]));
-                printf(" %s |",colour_int(gpu_counts[name]["PD","normal"]));
-                printf(" %s |",colour_int(gpu_counts[name]["CG","normal"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R","normal"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["PD","normal"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["CG","normal"]));
 
-                printf(" %s |",colour_int(gpu_counts[name]["R","overcap"]));
-                printf(" %s |",colour_int(gpu_counts[name]["PD","overcap"]));
-                printf(" %s |",colour_int(gpu_counts[name]["CG","overcap"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R","overcap"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["PD","overcap"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["CG","overcap"]));
 
-                printf(" %s |",colour_int(gpu_counts[name]["R"]));
-                printf(" %s |",colour_int(gpu_counts[name]["PD"]));
-                printf(" %s |",colour_int(gpu_counts[name]["CG"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["R"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["PD"]));
+                printf(" %s |",colour_int(gpu_counts[lab][name]["CG"]));
 
                 printf("\n");
             }


### PR DESCRIPTION
Currently, the lab is assigned arbitrarily if a user is associated with multiple lab accounts. This fix uses job-to-account mapping from squeue to count gpus under the right lab account.